### PR TITLE
adds render_fields function to generate form from schema

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,3 +35,5 @@ keys: System.get_env("ENCRYPTION_KEYS") # get the ENCRYPTION_KEYS env variable
   |> String.replace("'", "")  # remove single-quotes around key list in .env
   |> String.split(",")        # split the CSV list of keys
   |> Enum.map(fn key -> :base64.decode(key) end) # decode the key.
+
+import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,11 @@
+use Mix.Config
+
+# We don't run a server during test. If one is required,
+# you can enable the server option below.
+config :fields, TestFieldsWeb.Endpoint,
+  http: [port: 4001],
+  secret_key_base: "oU0T594I8GLngy1g5Bu6g3xBXwRFEMo5NFO4EbPPxo0gV4IAXIKWmOiM2gW/yiBp",
+  server: true
+
+# Print only warnings and errors during test
+config :logger, level: :warn

--- a/lib/fields.ex
+++ b/lib/fields.ex
@@ -4,15 +4,56 @@ defmodule Fields do
   """
 
   @doc """
-  Hello world.
+  Fields provides a function that can be used in a Phoenix Controller
+  to generate a form using an Ecto Schema.
 
-  ## Examples
+  Usage:
 
-      iex> Fields.hello
-      :world
+  At the top of your controller, call:
 
+      use Fields
+
+  then, when you want to render your form, call render_fields/4
   """
-  def hello do
-    :world
+  defmacro __using__(_opts) do
+    quote location: :keep do
+
+      @doc """
+        Renders a 'new' or 'update' form based on the schema passed to it.
+
+        Example:
+
+            render_fields(conn, :update, User, user: get_user_from_db())
+      """
+      @spec render_fields(Plug.Conn.t, atom, Ecto.Schema.t,  Keyword.t | map) :: Plug.Conn.t
+      def render_fields(conn, action, schema, assigns) when action in [:update, :create] do
+        fields = schema.__schema__(:fields) |> Enum.reject(&(&1 in [:id, :inserted_at, :updated_at]))
+
+        {_key, schema_data} = Enum.find(assigns, fn {_k, v} -> match?(v, schema) end)
+
+        action_path = path(conn, action, schema_data)
+
+        conn
+        |> put_view(Fields.FieldsView)
+        |> Phoenix.Controller.render(
+          "fields.html",
+          assigns
+          |> Enum.into(%{})
+          |> Map.put(:path, action_path)
+          |> Map.put(:fields, fields)
+        )
+      end
+
+      defp path(conn, action, opts) do
+        regex = ~r/(?<web_name>.+)\.(?<schema_name>.+)Controller/
+        %{"web_name" => web_name, "schema_name" => schema_name } = Regex.named_captures(regex, to_string(__MODULE__))
+
+        apply(
+          String.to_existing_atom(web_name <> ".Router.Helpers"),
+          String.to_existing_atom(String.downcase(schema_name) <> "_path"),
+          [conn, action, opts]
+        )
+      end
+    end
   end
 end

--- a/lib/fields.ex
+++ b/lib/fields.ex
@@ -29,7 +29,11 @@ defmodule Fields do
       def render_fields(conn, action, schema, assigns) when action in [:update, :create] do
         fields = schema.__schema__(:fields) |> Enum.reject(&(&1 in [:id, :inserted_at, :updated_at]))
 
-        {_key, schema_data} = Enum.find(assigns, fn {_k, v} -> match?(v, schema) end)
+        {_key, schema_data} =
+          case action do
+            :create -> {nil, []}
+            :update -> Enum.find(assigns, fn {_k, v} -> match?(v, schema) end)
+          end
 
         action_path = path(conn, action, schema_data)
 

--- a/lib/supervisor.ex
+++ b/lib/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Fields.Supervisor do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    # Run Fields Test App endpoint, when running tests
+    children =
+      case Code.ensure_compiled(TestFields) do
+        {:error, _} ->
+          []
+
+        {:module, TestFields} ->
+          [supervisor(TestFieldsWeb.Endpoint, [])]
+      end
+
+    opts = [strategy: :one_for_one, name: Fields.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/templates/fields/fields.html.eex
+++ b/lib/templates/fields/fields.html.eex
@@ -1,0 +1,1 @@
+<%= render "form.html", Map.put(assigns, :action, @path) %>

--- a/lib/templates/fields/form.html.eex
+++ b/lib/templates/fields/form.html.eex
@@ -1,0 +1,18 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+  <%= for field <- @fields do %>
+    <div class="form-group">
+      <%= label f, field, class: "control-label" %>
+      <%= input f, field, class: "form-control" %>
+      <%= error_tag f, field %>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/lib/views/error_helpers.ex
+++ b/lib/views/error_helpers.ex
@@ -1,0 +1,44 @@
+defmodule Fields.ErrorHelpers do
+  @moduledoc """
+  Conveniences for translating and building error messages.
+  """
+
+  use Phoenix.HTML
+
+  @doc """
+  Generates tag for inlined form input errors.
+  """
+  def error_tag(form, field) do
+    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
+      content_tag :span, translate_error(error), class: "help-block"
+    end)
+  end
+
+  @doc """
+  Translates an error message using gettext.
+  """
+  def translate_error({msg, opts}) do
+    # When using gettext, we typically pass the strings we want
+    # to translate as a static argument:
+    #
+    #     # Translate "is invalid" in the "errors" domain
+    #     dgettext "errors", "is invalid"
+    #
+    #     # Translate the number of files with plural rules
+    #     dngettext "errors", "1 file", "%{count} files", count
+    #
+    # Because the error messages we show in our forms and APIs
+    # are defined inside Ecto, we need to translate them dynamically.
+    # This requires us to call the Gettext module passing our gettext
+    # backend as first argument.
+    #
+    # Note we use the "errors" domain, which means translations
+    # should be written to the errors.po file. The :count option is
+    # set by Ecto and indicates we should also apply plural rules.
+    if count = opts[:count] do
+      Gettext.dngettext(ReusableWeb.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(ReusableWeb.Gettext, "errors", msg, opts)
+    end
+  end
+end

--- a/lib/views/fields_view.ex
+++ b/lib/views/fields_view.ex
@@ -1,0 +1,11 @@
+defmodule Fields.FieldsView do
+  use Phoenix.View, root: "lib/templates"
+  use Phoenix.HTML
+  import Phoenix.HTML.Form
+  import Fields.ErrorHelpers
+
+  def input(form, field, opts) do
+    type = Phoenix.HTML.Form.input_type(form, field)
+    apply(Phoenix.HTML.Form, type, [form, field, opts])
+  end
+end

--- a/lib/views/fields_view.ex
+++ b/lib/views/fields_view.ex
@@ -1,5 +1,5 @@
 defmodule Fields.FieldsView do
-  use Phoenix.View, root: "lib/templates"
+  use Phoenix.View, root: "lib/templates", pattern: "**/*"
   use Phoenix.HTML
   import Phoenix.HTML.Form
   import Fields.ErrorHelpers

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Fields.MixProject do
       app: :fields,
       version: "0.1.0",
       elixir: "~> 1.6",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       compilers: [:phoenix, :gettext] ++ Mix.compilers,
       deps: deps()
@@ -15,9 +16,14 @@ defmodule Fields.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {Fields.Supervisor, []},
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
@@ -26,6 +32,7 @@ defmodule Fields.MixProject do
       {:phoenix_ecto, "~> 3.2"},
       {:phoenix_html, "~> 2.10"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:cowboy, "~> 1.0"},
       {:gettext, "~> 0.11"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Fields.MixProject do
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
+      compilers: [:phoenix, :gettext] ++ Mix.compilers,
       deps: deps()
     ]
   end
@@ -21,8 +22,11 @@ defmodule Fields.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:phoenix, "~> 1.3.4"},
+      {:phoenix_ecto, "~> 3.2"},
+      {:phoenix_html, "~> 2.10"},
+      {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:gettext, "~> 0.11"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,8 @@
 %{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
@@ -12,4 +16,6 @@
   "plug": {:hex, :plug, "1.6.3", "43088304337b9e8b8bd22a0383ca2f633519697e4c11889285538148f42cbc5e", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,15 @@
+%{
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.16.0", "4a7e90408cef5f1bf57c5a39e2db8c372a906031cc9b1466e963101cb927dafc", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.3.4", "aaa1b55e5523083a877bcbe9886d9ee180bf2c8754905323493c2ac325903dc5", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_ecto": {:hex, :phoenix_ecto, "3.4.0", "91cd39427006fe4b5588d69f0941b9c3d3d8f5e6477c563a08379de7de2b0c58", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: false]}, {:phoenix_html, "~> 2.9", [hex: :phoenix_html, repo: "hexpm", optional: true]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_html": {:hex, :phoenix_html, "2.12.0", "1fb3c2e48b4b66d75564d8d63df6d53655469216d6b553e7e14ced2b46f97622", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.1.5", "8d4c9b1ef9ca82deee6deb5a038d6d8d7b34b9bb909d99784a49332e0d15b3dc", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.0", "d55e25ff1ff8ea2f9964638366dfd6e361c52dedfd50019353598d11d4441d14", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.3", "43088304337b9e8b8bd22a0383ca2f633519697e4c11889285538148f42cbc5e", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+}

--- a/test/fields_test.exs
+++ b/test/fields_test.exs
@@ -1,8 +1,56 @@
 defmodule FieldsTest do
-  use ExUnit.Case
+  use TestFieldsWeb.ConnCase
   doctest Fields
 
-  test "greets the world" do
-    assert Fields.hello() == :world
+  describe "GET /users/new" do
+    test "Correct fields exist", %{conn: conn} do
+      assert response =
+        conn
+        |> get(user_path(conn, :new))
+        |> html_response(200)
+
+      assert response =~ "age"
+      assert response =~ "name"
+    end
+
+    test "Correct form action", %{conn: conn} do
+      assert response =
+        conn
+        |> get(user_path(conn, :new))
+        |> html_response(200)
+
+      assert response =~ ~s(action="/users")
+    end
+  end
+
+  describe "GET /users/1/edit" do
+    test "Correct fields exist", %{conn: conn} do
+      assert response =
+        conn
+        |> get(user_path(conn, :edit, 1))
+        |> html_response(200)
+
+      assert response =~ "age"
+      assert response =~ "name"
+    end
+
+    test "Existing data prefilled in form", %{conn: conn} do
+      assert response =
+        conn
+        |> get(user_path(conn, :edit, 1))
+        |> html_response(200)
+
+      assert response =~ "Test User"
+      assert response =~ "55"
+    end
+
+    test "Correct form action", %{conn: conn} do
+      assert response =
+        conn
+        |> get(user_path(conn, :edit, 1))
+        |> html_response(200)
+
+      assert response =~ ~s(action="/users/1")
+    end
   end
 end

--- a/test/support/test_fields/lib/test_fields.ex
+++ b/test/support/test_fields/lib/test_fields.ex
@@ -1,0 +1,9 @@
+defmodule TestFields do
+  @moduledoc """
+  TestFields keeps the contexts that define your domain
+  and business logic.
+
+  Contexts are also responsible for managing your data, regardless
+  if it comes from the database, an external API or others.
+  """
+end

--- a/test/support/test_fields/lib/test_fields/application.ex
+++ b/test/support/test_fields/lib/test_fields/application.ex
@@ -1,0 +1,31 @@
+defmodule TestFields.Application do
+  use Application
+
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      # Start the Ecto repository
+      supervisor(TestFields.Repo, []),
+      # Start the endpoint when the application starts
+      supervisor(TestFieldsWeb.Endpoint, []),
+      # Start your own worker by calling: TestFields.Worker.start_link(arg1, arg2, arg3)
+      # worker(TestFields.Worker, [arg1, arg2, arg3]),
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: TestFields.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  # Tell Phoenix to update the endpoint configuration
+  # whenever the application is updated.
+  def config_change(changed, _new, removed) do
+    TestFieldsWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/test/support/test_fields/lib/test_fields/user.ex
+++ b/test/support/test_fields/lib/test_fields/user.ex
@@ -1,0 +1,19 @@
+defmodule TestFields.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+
+  schema "users" do
+    field :age, :integer
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:name, :age])
+    |> validate_required([:name, :age])
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web.ex
+++ b/test/support/test_fields/lib/test_fields_web.ex
@@ -1,0 +1,64 @@
+defmodule TestFieldsWeb do
+  @moduledoc """
+  The entrypoint for defining your web interface, such
+  as controllers, views, channels and so on.
+
+  This can be used in your application as:
+
+      use TestFieldsWeb, :controller
+      use TestFieldsWeb, :view
+
+  The definitions below will be executed for every view,
+  controller, etc, so keep them short and clean, focused
+  on imports, uses and aliases.
+
+  Do NOT define functions inside the quoted expressions
+  below. Instead, define any helper function in modules
+  and import those modules here.
+  """
+
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: TestFieldsWeb
+      import Plug.Conn
+      import TestFieldsWeb.Router.Helpers
+    end
+  end
+
+  def view do
+    quote do
+      use Phoenix.View, root: "test/support/test_fields/lib/test_fields_web/templates", pattern: "**/*",
+                        namespace: TestFieldsWeb
+
+      # Import convenience functions from controllers
+      import Phoenix.Controller, only: [get_flash: 2, view_module: 1]
+
+      # Use all HTML functionality (forms, tags, etc)
+      use Phoenix.HTML
+
+      import TestFieldsWeb.Router.Helpers
+      import TestFieldsWeb.ErrorHelpers
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+      import Plug.Conn
+      import Phoenix.Controller
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  @doc """
+  When used, dispatch to the appropriate controller/view/etc.
+  """
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web/channels/user_socket.ex
+++ b/test/support/test_fields/lib/test_fields_web/channels/user_socket.ex
@@ -1,0 +1,37 @@
+defmodule TestFieldsWeb.UserSocket do
+  use Phoenix.Socket
+
+  ## Channels
+  # channel "room:*", TestFieldsWeb.RoomChannel
+
+  ## Transports
+  transport :websocket, Phoenix.Transports.WebSocket
+  # transport :longpoll, Phoenix.Transports.LongPoll
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error`.
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  def connect(_params, socket) do
+    {:ok, socket}
+  end
+
+  # Socket id's are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     TestFieldsWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  def id(_socket), do: nil
+end

--- a/test/support/test_fields/lib/test_fields_web/controllers/user_controller.ex
+++ b/test/support/test_fields/lib/test_fields_web/controllers/user_controller.ex
@@ -1,15 +1,8 @@
 defmodule TestFieldsWeb.UserController do
   use TestFieldsWeb, :controller
-
-  alias TestFields.User
-
   use Fields
 
-  def index(conn, _params) do
-    # users = Accounts.list_users()
-    # render(conn, "index.html", users: users)
-    conn
-  end
+  alias TestFields.User
 
   def new(conn, _params) do
     changeset = User.changeset(%User{}, %{})
@@ -17,55 +10,11 @@ defmodule TestFieldsWeb.UserController do
     render_fields(conn, :create, User, changeset: changeset)
   end
 
-  def create(conn, %{"user" => user_params}) do
-    # case Accounts.create_user(user_params) do
-    #   {:ok, user} ->
-    #     conn
-    #     |> put_flash(:info, "User created successfully.")
-    #     |> redirect(to: user_path(conn, :show, user))
-    #   {:error, %Ecto.Changeset{} = changeset} ->
-    #     render(conn, "new.html", changeset: changeset)
-    # end
-    conn
-  end
-
-  def show(conn, %{"id" => id}) do
-    # user = Accounts.get_user!(id)
-    # render(conn, "show.html", user: user)
-    conn
-  end
-
   def edit(conn, %{"id" => id}) do
-    # user = Accounts.get_user!(id)
-    # changeset = Accounts.change_user(user)
+    user = %User{name: "Test User", age: "55", id: id}
+    changeset = User.changeset(user, %{})
 
-    # conn
-    # |> render_fields(:update, User, user: user, changeset: changeset)
     conn
-  end
-
-  def update(conn, %{"id" => id, "user" => user_params}) do
-    # IO.inspect id
-    # user = Accounts.get_user!(id)
-
-    # case Accounts.update_user(user, user_params) do
-    #   {:ok, user} ->
-    #     conn
-    #     |> put_flash(:info, "User updated successfully.")
-    #     |> redirect(to: user_path(conn, :show, user))
-    #   {:error, %Ecto.Changeset{} = changeset} ->
-    #     render(conn, "edit.html", user: user, changeset: changeset)
-    # end
-    conn
-  end
-
-  def delete(conn, %{"id" => id}) do
-    # user = Accounts.get_user!(id)
-    # {:ok, _user} = Accounts.delete_user(user)
-
-    # conn
-    # |> put_flash(:info, "User deleted successfully.")
-    # |> redirect(to: user_path(conn, :index))
-    conn
+    |> render_fields(:update, User, user: user, changeset: changeset)
   end
 end

--- a/test/support/test_fields/lib/test_fields_web/controllers/user_controller.ex
+++ b/test/support/test_fields/lib/test_fields_web/controllers/user_controller.ex
@@ -1,0 +1,71 @@
+defmodule TestFieldsWeb.UserController do
+  use TestFieldsWeb, :controller
+
+  alias TestFields.User
+
+  use Fields
+
+  def index(conn, _params) do
+    # users = Accounts.list_users()
+    # render(conn, "index.html", users: users)
+    conn
+  end
+
+  def new(conn, _params) do
+    changeset = User.changeset(%User{}, %{})
+
+    render_fields(conn, :create, User, changeset: changeset)
+  end
+
+  def create(conn, %{"user" => user_params}) do
+    # case Accounts.create_user(user_params) do
+    #   {:ok, user} ->
+    #     conn
+    #     |> put_flash(:info, "User created successfully.")
+    #     |> redirect(to: user_path(conn, :show, user))
+    #   {:error, %Ecto.Changeset{} = changeset} ->
+    #     render(conn, "new.html", changeset: changeset)
+    # end
+    conn
+  end
+
+  def show(conn, %{"id" => id}) do
+    # user = Accounts.get_user!(id)
+    # render(conn, "show.html", user: user)
+    conn
+  end
+
+  def edit(conn, %{"id" => id}) do
+    # user = Accounts.get_user!(id)
+    # changeset = Accounts.change_user(user)
+
+    # conn
+    # |> render_fields(:update, User, user: user, changeset: changeset)
+    conn
+  end
+
+  def update(conn, %{"id" => id, "user" => user_params}) do
+    # IO.inspect id
+    # user = Accounts.get_user!(id)
+
+    # case Accounts.update_user(user, user_params) do
+    #   {:ok, user} ->
+    #     conn
+    #     |> put_flash(:info, "User updated successfully.")
+    #     |> redirect(to: user_path(conn, :show, user))
+    #   {:error, %Ecto.Changeset{} = changeset} ->
+    #     render(conn, "edit.html", user: user, changeset: changeset)
+    # end
+    conn
+  end
+
+  def delete(conn, %{"id" => id}) do
+    # user = Accounts.get_user!(id)
+    # {:ok, _user} = Accounts.delete_user(user)
+
+    # conn
+    # |> put_flash(:info, "User deleted successfully.")
+    # |> redirect(to: user_path(conn, :index))
+    conn
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web/endpoint.ex
+++ b/test/support/test_fields/lib/test_fields_web/endpoint.ex
@@ -1,0 +1,56 @@
+defmodule TestFieldsWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :fields
+
+  socket "/socket", TestFieldsWeb.UserSocket
+
+  # Serve at "/" the static files from "priv/static" directory.
+  #
+  # You should set gzip to true if you are running phoenix.digest
+  # when deploying your static files in production.
+  plug Plug.Static,
+    at: "/", from: :test_fields, gzip: false,
+    only: ~w(css fonts images js favicon.ico robots.txt)
+
+  # Code reloading can be explicitly enabled under the
+  # :code_reloader configuration of your endpoint.
+  if code_reloading? do
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader
+  end
+
+  plug Plug.Logger
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  # The session will be stored in the cookie and signed,
+  # this means its contents can be read but not tampered with.
+  # Set :encryption_salt if you would also like to encrypt it.
+  plug Plug.Session,
+    store: :cookie,
+    key: "_test_fields_key",
+    signing_salt: "6pJJExUN"
+
+  plug TestFieldsWeb.Router
+
+  @doc """
+  Callback invoked for dynamically configuring the endpoint.
+
+  It receives the endpoint configuration and checks if
+  configuration should be loaded from the system environment.
+  """
+  def init(_key, config) do
+    if config[:load_from_system_env] do
+      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
+      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+    else
+      {:ok, config}
+    end
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web/router.ex
+++ b/test/support/test_fields/lib/test_fields_web/router.ex
@@ -1,0 +1,27 @@
+defmodule TestFieldsWeb.Router do
+  use TestFieldsWeb, :router
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/", TestFieldsWeb do
+    pipe_through :browser # Use the default browser stack
+
+    get "/", PageController, :index
+    resources "/users", UserController
+  end
+
+  # Other scopes may use custom stacks.
+  # scope "/api", TestFieldsWeb do
+  #   pipe_through :api
+  # end
+end

--- a/test/support/test_fields/lib/test_fields_web/templates/layout/app.html.eex
+++ b/test/support/test_fields/lib/test_fields_web/templates/layout/app.html.eex
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Hello TestFields!</title>
+    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+  </head>
+
+  <body>
+    <div class="container">
+      <header class="header">
+        <nav role="navigation">
+          <ul class="nav nav-pills pull-right">
+            <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
+          </ul>
+        </nav>
+        <span class="logo"></span>
+      </header>
+
+      <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
+      <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+
+      <main role="main">
+        <%= render @view_module, @view_template, assigns %>
+      </main>
+
+    </div> <!-- /container -->
+    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
+  </body>
+</html>

--- a/test/support/test_fields/lib/test_fields_web/views/error_helpers.ex
+++ b/test/support/test_fields/lib/test_fields_web/views/error_helpers.ex
@@ -1,0 +1,44 @@
+defmodule TestFieldsWeb.ErrorHelpers do
+  @moduledoc """
+  Conveniences for translating and building error messages.
+  """
+
+  use Phoenix.HTML
+
+  @doc """
+  Generates tag for inlined form input errors.
+  """
+  def error_tag(form, field) do
+    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
+      content_tag :span, translate_error(error), class: "help-block"
+    end)
+  end
+
+  @doc """
+  Translates an error message using gettext.
+  """
+  def translate_error({msg, opts}) do
+    # When using gettext, we typically pass the strings we want
+    # to translate as a static argument:
+    #
+    #     # Translate "is invalid" in the "errors" domain
+    #     dgettext "errors", "is invalid"
+    #
+    #     # Translate the number of files with plural rules
+    #     dngettext "errors", "1 file", "%{count} files", count
+    #
+    # Because the error messages we show in our forms and APIs
+    # are defined inside Ecto, we need to translate them dynamically.
+    # This requires us to call the Gettext module passing our gettext
+    # backend as first argument.
+    #
+    # Note we use the "errors" domain, which means translations
+    # should be written to the errors.po file. The :count option is
+    # set by Ecto and indicates we should also apply plural rules.
+    if count = opts[:count] do
+      Gettext.dngettext(TestFieldsWeb.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(TestFieldsWeb.Gettext, "errors", msg, opts)
+    end
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web/views/error_view.ex
+++ b/test/support/test_fields/lib/test_fields_web/views/error_view.ex
@@ -1,0 +1,16 @@
+defmodule TestFieldsWeb.ErrorView do
+  use TestFieldsWeb, :view
+
+  # If you want to customize a particular status code
+  # for a certain format, you may uncomment below.
+  # def render("500.html", _assigns) do
+  #   "Internal Server Error"
+  # end
+
+  # By default, Phoenix returns the status message from
+  # the template name. For example, "404.html" becomes
+  # "Not Found".
+  def template_not_found(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
+end

--- a/test/support/test_fields/lib/test_fields_web/views/layout_view.ex
+++ b/test/support/test_fields/lib/test_fields_web/views/layout_view.ex
@@ -1,0 +1,3 @@
+defmodule TestFieldsWeb.LayoutView do
+  use TestFieldsWeb, :view
+end

--- a/test/support/test_fields/lib/test_fields_web/views/user_view.ex
+++ b/test/support/test_fields/lib/test_fields_web/views/user_view.ex
@@ -1,0 +1,3 @@
+defmodule TestFieldsWeb.UserView do
+  use TestFieldsWeb, :view
+end

--- a/test/support/test_fields/test/support/channel_case.ex
+++ b/test/support/test_fields/test/support/channel_case.ex
@@ -1,0 +1,37 @@
+defmodule TestFieldsWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+
+  Such tests rely on `Phoenix.ChannelTest` and also
+  import other functionality to make it easier
+  to build common datastructures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use Phoenix.ChannelTest
+
+      # The default endpoint for testing
+      @endpoint TestFieldsWeb.Endpoint
+    end
+  end
+
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestFields.Repo)
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(TestFields.Repo, {:shared, self()})
+    end
+    :ok
+  end
+
+end

--- a/test/support/test_fields/test/support/conn_case.ex
+++ b/test/support/test_fields/test/support/conn_case.ex
@@ -1,0 +1,34 @@
+defmodule TestFieldsWeb.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Such tests rely on `Phoenix.ConnTest` and also
+  import other functionality to make it easier
+  to build common datastructures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      use Phoenix.ConnTest
+      import TestFieldsWeb.Router.Helpers
+
+      # The default endpoint for testing
+      @endpoint TestFieldsWeb.Endpoint
+    end
+  end
+
+
+  setup tags do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+end

--- a/test/support/test_fields/test/support/data_case.ex
+++ b/test/support/test_fields/test/support/data_case.ex
@@ -1,0 +1,53 @@
+defmodule TestFields.DataCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's data layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias TestFields.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import TestFields.DataCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestFields.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(TestFields.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+
+  @doc """
+  A helper that transform changeset errors to a map of messages.
+
+      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
+      assert "password is too short" in errors_on(changeset).password
+      assert %{password: ["password is too short"]} = errors_on(changeset)
+
+  """
+  def errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Enum.reduce(opts, message, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/test/support/test_fields/test/test_helper.exs
+++ b/test/support/test_fields/test/test_helper.exs
@@ -1,0 +1,4 @@
+ExUnit.start()
+
+Ecto.Adapters.SQL.Sandbox.mode(TestFields.Repo, :manual)
+


### PR DESCRIPTION
Adds `render_fields/4` function, which can be called from a Phoenix Controller, and will generate a form for either an `:update` or `:create` ('edit' or 'new') action, based on a given schema.

ref #6, https://github.com/dwyl/adoro/issues/108

I'm going to add some more tests before it's ready for merge, plus I've temporarily removed the code that was used to incrementally update the data, as it was causing issues with updates being submitted too many times.