### PR TITLE
Hash, Password, Email and Encrypted fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ erl_crash.dump
 fields-*.tar
 
 .env
+
+.elixir_ls

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,11 +27,16 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+if Mix.env() == :test, do: import_config("#{Mix.env()}.exs")
 
 # Set the Encryption Keys as an "Application Variable" accessible in aes.ex
 config :fields, Fields.AES,
-keys: System.get_env("ENCRYPTION_KEYS") # get the ENCRYPTION_KEYS env variable
-  |> String.replace("'", "")  # remove single-quotes around key list in .env
-  |> String.split(",")        # split the CSV list of keys
-  |> Enum.map(fn key -> :base64.decode(key) end) # decode the key.
+  # get the ENCRYPTION_KEYS env variable
+  keys:
+    System.get_env("ENCRYPTION_KEYS")
+    # remove single-quotes around key list in .env
+    |> String.replace("'", "")
+    # split the CSV list of keys
+    |> String.split(",")
+    # decode the key.
+    |> Enum.map(fn key -> :base64.decode(key) end)

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :fields, Fields,
+  secret_key_base: "rVOUu+QTva+VlRJJI3wSYONRoffFQH167DfiZcegvYY/PEasjPLKIDz7wPTvTPIP"

--- a/lib/email_encrypted.ex
+++ b/lib/email_encrypted.ex
@@ -1,0 +1,15 @@
+defmodule Fields.EmailEncrypted do
+  alias Fields.{EmailPlaintext, Encrypted, Validate}
+
+  @behaviour Ecto.Type
+
+  def type, do: :binary
+
+  def cast(value), do: EmailPlaintext.cast(value)
+
+  def dump(value), do: Encrypted.dump(value)
+
+  def load(value), do: Encrypted.load(value)
+
+  def load(value, key_id), do: Encrypted.load(value, key_id)
+end

--- a/lib/email_encrypted.ex
+++ b/lib/email_encrypted.ex
@@ -1,4 +1,13 @@
 defmodule Fields.EmailEncrypted do
+  @moduledoc """
+  An Ecto Type for encrypted emails.
+
+  ## Example
+
+      schema "users" do
+        field(:email, Fields.EmailEncrypted)
+      end
+  """
   alias Fields.{EmailPlaintext, Encrypted, Validate}
 
   @behaviour Ecto.Type

--- a/lib/email_hash.ex
+++ b/lib/email_hash.ex
@@ -1,4 +1,16 @@
 defmodule Fields.EmailHash do
+  @moduledoc """
+  An Ecto Type for hashed emails.
+  Use in conjuction with `Fields.EmailEncrypted` in order to be able to look up database rows by email.
+  Hashed using sha256. See `Fields.Helpers` for hashing details.
+
+  ## Example
+
+      schema "users" do
+        field(:email, Fields.EmailEncrypted)
+        field(:email_hash, Fields.EmailHash)
+      end
+  """
   alias Fields.{EmailPlaintext, Hash}
 
   @behaviour Ecto.Type

--- a/lib/email_hash.ex
+++ b/lib/email_hash.ex
@@ -1,0 +1,15 @@
+defmodule Fields.EmailHash do
+  alias Fields.{EmailPlaintext, Hash}
+
+  @behaviour Ecto.Type
+
+  def type, do: :binary
+
+  def cast(value), do: EmailPlaintext.cast(value)
+
+  def dump(value), do: Hash.dump(value)
+
+  def load(value) do
+    {:ok, value}
+  end
+end

--- a/lib/email_plaintext.ex
+++ b/lib/email_plaintext.ex
@@ -1,4 +1,15 @@
 defmodule Fields.EmailPlaintext do
+  @moduledoc """
+  An Ecto Type for plaintext emails.
+  Useful for publicly available email addressses such as customer support emails.
+  See `Fields.EmailEncrypted` and `Fields.EmailHash` for storing user email addresses.
+
+  ## Example
+
+        schema "retailers" do
+          field(:email, Fields.EmailPlaintext)
+        end
+  """
   alias Fields.Validate
 
   @behaviour Ecto.Type

--- a/lib/email_plaintext.ex
+++ b/lib/email_plaintext.ex
@@ -1,0 +1,22 @@
+defmodule Fields.EmailPlaintext do
+  alias Fields.Validate
+
+  @behaviour Ecto.Type
+
+  def type, do: :string
+
+  def cast(value) do
+    case Validate.email(value) do
+      true -> {:ok, to_string(value)}
+      false -> {:error, email: :invalid}
+    end
+  end
+
+  def dump(value) do
+    {:ok, to_string(value)}
+  end
+
+  def load(value) do
+    {:ok, value}
+  end
+end

--- a/lib/encrypted.ex
+++ b/lib/encrypted.ex
@@ -1,4 +1,14 @@
 defmodule Fields.Encrypted do
+  @moduledoc """
+  An Ecto Type for encrypted fields.
+  See `Fields.AES` for details on encryption/decryption.
+
+  ## Example
+
+        schema "users" do
+          field(:name, Fields.Encrypted)
+        end
+  """
   alias Fields.AES
 
   @behaviour Ecto.Type

--- a/lib/encrypted.ex
+++ b/lib/encrypted.ex
@@ -1,0 +1,23 @@
+defmodule Fields.Encrypted do
+  alias Fields.AES
+
+  @behaviour Ecto.Type
+  def type, do: :binary
+
+  def cast(value) do
+    {:ok, to_string(value)}
+  end
+
+  def dump(value) do
+    ciphertext = value |> to_string |> AES.encrypt()
+    {:ok, ciphertext}
+  end
+
+  def load(value) do
+    {:ok, AES.decrypt(value)}
+  end
+
+  def load(value, key_id) do
+    {:ok, AES.decrypt(value, key_id)}
+  end
+end

--- a/lib/hash.ex
+++ b/lib/hash.ex
@@ -1,4 +1,14 @@
 defmodule Fields.Hash do
+  @moduledoc """
+  An Ecto Type for hashed fields.
+  Hashed using sha256. See `Fields.Helpers` for hashing details.
+
+  ## Example
+
+        schema "messages" do
+          field(:digest, Fields.Hash)
+        end
+  """
   @behaviour Ecto.Type
 
   alias Fields.Helpers

--- a/lib/hash.ex
+++ b/lib/hash.ex
@@ -1,0 +1,19 @@
+defmodule Fields.Hash do
+  @behaviour Ecto.Type
+
+  alias Fields.Helpers
+
+  def type, do: :binary
+
+  def cast(value) do
+    {:ok, to_string(value)}
+  end
+
+  def dump(value) do
+    {:ok, Helpers.hash(:sha256, value)}
+  end
+
+  def load(value) do
+    {:ok, value}
+  end
+end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -8,4 +8,18 @@ defmodule Fields.Helpers do
   def hash(:argon2, value) do
     Argon2.Base.hash_password(to_string(value), Argon2.gen_salt(), [{:argon2_type, 2}])
   end
+
+  @doc """
+  Hash a string, or a value that implements the String.Chars protocol, using
+  sha256. sha256 is fast, but not as strong as Argon2, so not recommended for hashing passwords.
+  """
+  @spec hash(atom(), String.Chars.t()) :: String.t()
+  def hash(:sha256, value) do
+    :crypto.hash(:sha256, to_string(value) <> get_salt(to_string(value)))
+  end
+
+  defp get_salt(value) do
+    secret_key_base = Application.get_env(:fields, Fields)[:secret_key_base]
+    :crypto.hash(:sha256, value <> secret_key_base)
+  end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -1,0 +1,11 @@
+defmodule Fields.Helpers do
+  @doc """
+  Hash a string, or a value that implements the String.Chars protocol, using
+  Argon2. Argon2 is a strong but slow hashing function, so is recommended
+  for passwords.
+  """
+  @spec hash(atom(), String.Chars.t()) :: String.t()
+  def hash(:argon2, value) do
+    Argon2.Base.hash_password(to_string(value), Argon2.gen_salt(), [{:argon2_type, 2}])
+  end
+end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -11,7 +11,8 @@ defmodule Fields.Helpers do
 
   @doc """
   Hash a string, or a value that implements the String.Chars protocol, using
-  sha256. sha256 is fast, but not as strong as Argon2, so not recommended for hashing passwords.
+  sha256. sha256 is fast, but not as strong as Argon2,
+  so it is not recommended for hashing passwords.
   """
   @spec hash(atom(), String.Chars.t()) :: String.t()
   def hash(:sha256, value) do

--- a/lib/password.ex
+++ b/lib/password.ex
@@ -1,0 +1,19 @@
+defmodule Fields.Password do
+  @behaviour Ecto.Type
+
+  alias Fields.Helpers
+
+  def type, do: :binary
+
+  def cast(value) do
+    {:ok, to_string(value)}
+  end
+
+  def dump(value) do
+    {:ok, Helpers.hash(:argon2, value)}
+  end
+
+  def load(value) do
+    {:ok, value}
+  end
+end

--- a/lib/password.ex
+++ b/lib/password.ex
@@ -1,4 +1,15 @@
 defmodule Fields.Password do
+  @moduledoc """
+  An Ecto Type for hashed passwords.
+  Hashed using Argon2. See `Fields.Helpers` for hashing details.
+
+  ## Example
+
+      schema "users" do
+        field(:email, Fields.EmailEncrypted)
+        field(:password, Fields.Password)
+      end
+  """
   @behaviour Ecto.Type
 
   alias Fields.Helpers

--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -1,10 +1,20 @@
 defmodule Fields.Validate do
+  @moduledoc """
+  Helper functions to validate the data in certain fields
+  """
+
+  @doc """
+  Validate the format of an email address using a regex.
+  Uses a slightly modified version of the w3c HTML5 spec email regex (https://www.w3.org/TR/html5/forms.html#valid-e-mail-address),
+  with additions to account for not allowing emails to start or end with '.',
+  and a check that there are no consecutive '.'s.
+  """
   def email(email) do
     {:ok, regex} =
       Regex.compile(
-        "^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*(?<!\\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+        "^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*(?<!\\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
       )
 
-    Regex.match?(regex, email)
+    Regex.match?(regex, email) && !String.contains?(email, "..")
   end
 end

--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -1,0 +1,10 @@
+defmodule Fields.Validate do
+  def email(email) do
+    {:ok, regex} =
+      Regex.compile(
+        "^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*(?<!\\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+      )
+
+    Regex.match?(regex, email)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Fields.MixProject do
     [
       app: :fields,
       version: "0.1.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -21,7 +21,8 @@ defmodule Fields.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
+      {:argon2_elixir, "~> 1.2"},
+      {:ecto, "~> 2.2.10"}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Fields.MixProject do
   def project do
     [
       app: :fields,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule Fields.MixProject do
   defp deps do
     [
       {:argon2_elixir, "~> 1.2"},
-      {:ecto, "~> 2.2.10"}
+      {:ecto, "~> 2.2.10"},
+      {:stream_data, "~> 0.4.2", only: :test}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "argon2_elixir": {:hex, :argon2_elixir, "1.3.1", "02a3d55a2670d25df25d75adcef2d74662c72bbc85aba17ca0ea585764b59ef4", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -4,4 +4,5 @@
   "ecto": {:hex, :ecto, "2.2.11", "4bb8f11718b72ba97a2696f65d247a379e739a0ecabf6a13ad1face79844791c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
   "argon2_elixir": {:hex, :argon2_elixir, "1.3.1", "02a3d55a2670d25df25d75adcef2d74662c72bbc85aba17ca0ea585764b59ef4", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.11", "4bb8f11718b72ba97a2696f65d247a379e739a0ecabf6a13ad1face79844791c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
 }

--- a/test/email_test.exs
+++ b/test/email_test.exs
@@ -1,0 +1,74 @@
+defmodule Fields.EmailTest do
+  use ExUnit.Case
+  alias Fields.{EmailPlaintext, EmailHash, EmailEncrypted}
+
+  describe "types" do
+    test "EmailPlaintext.type is :string" do
+      assert EmailPlaintext.type() == :string
+    end
+
+    test "EmailEncrypted.type is :binary" do
+      assert EmailEncrypted.type() == :binary
+    end
+
+    test "EmailHash.type is :binary" do
+      assert EmailHash.type() == :binary
+    end
+  end
+
+  describe "cast" do
+    test "Email.cast accepts a string" do
+      assert {:ok, "test@test.com"} == EmailPlaintext.cast("test@test.com")
+      assert {:ok, "test@test.com"} == EmailEncrypted.cast("test@test.com")
+      assert {:ok, "test@test.com"} == EmailHash.cast("test@test.com")
+    end
+
+    test "Email.cast validates email" do
+      assert {:error, [email: :invalid]} == EmailPlaintext.cast("invalid_email")
+      assert {:error, [email: :invalid]} == EmailEncrypted.cast("invalid_email")
+      assert {:error, [email: :invalid]} == EmailHash.cast("invalid_email")
+    end
+  end
+
+  describe "dump" do
+    test "EmailEncrypted.dump encrypts a value" do
+      {:ok, ciphertext} = EmailEncrypted.dump("test@test.com")
+
+      assert ciphertext != "test@test.com"
+      assert String.length(ciphertext) != 0
+    end
+
+    test "EmailHash.dump converts a value to a sha256 hash" do
+      {:ok, hash} = EmailHash.dump("test@test.com")
+
+      assert hash ==
+               <<217, 149, 14, 81, 96, 74, 72, 128, 75, 76, 49, 62, 14, 210, 156, 157, 103, 210,
+                 53, 230, 76, 0, 157, 233, 152, 39, 164, 209, 158, 219, 72, 28>>
+    end
+
+    test "EmailPlaintext.dump returns a string" do
+      assert {:ok, "test@test.com"} == EmailPlaintext.dump("test@test.com")
+    end
+  end
+
+  describe "load" do
+    test "EmailEncrypted.load decrypts a value" do
+      {:ok, ciphertext} = EmailEncrypted.dump("test@test.com")
+      keys = Application.get_env(:fields, Fields.AES)[:keys]
+      key_id = Enum.count(keys) - 1
+      assert {:ok, "test@test.com"} == EmailEncrypted.load(ciphertext, key_id)
+    end
+
+    test "EmailHash.load does not modify the hash, since the hash cannot be reversed" do
+      hash =
+        <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16, 75, 46, 161, 206, 219,
+          141, 203, 199, 88, 112, 1, 204, 189, 109, 248, 22, 254>>
+
+      assert {:ok, ^hash} = EmailHash.load(hash)
+    end
+
+    test "EmailPlaintext.load returns a string" do
+      assert {:ok, "test@test.com"} == EmailPlaintext.load("test@test.com")
+    end
+  end
+end

--- a/test/encrypted_test.exs
+++ b/test/encrypted_test.exs
@@ -1,0 +1,26 @@
+defmodule Fields.EncryptedTest do
+  use ExUnit.Case
+  alias Fields.Encrypted
+
+  test ".type is :binary" do
+    assert Encrypted.type() == :binary
+  end
+
+  test ".cast converts a value to a string" do
+    assert {:ok, "123"} == Encrypted.cast(123)
+  end
+
+  test ".dump encrypts a value" do
+    {:ok, ciphertext} = Encrypted.dump("hello")
+
+    assert ciphertext != "hello"
+    assert String.length(ciphertext) != 0
+  end
+
+  test ".load decrypts a value" do
+    {:ok, ciphertext} = Encrypted.dump("hello")
+    keys = Application.get_env(:fields, Fields.AES)[:keys]
+    key_id = Enum.count(keys) - 1
+    assert {:ok, "hello"} == Encrypted.load(ciphertext, key_id)
+  end
+end

--- a/test/hash_test.exs
+++ b/test/hash_test.exs
@@ -1,0 +1,29 @@
+defmodule Fields.HashTest do
+  use ExUnit.Case
+  alias Fields.Hash
+
+  test ".type is :binary" do
+    assert Hash.type() == :binary
+  end
+
+  test ".cast converts a value to a string" do
+    assert {:ok, "42"} == Hash.cast(42)
+    assert {:ok, "atom"} == Hash.cast(:atom)
+  end
+
+  test ".dump converts a value to a sha256 hash" do
+    {:ok, hash} = Hash.dump("hello")
+
+    assert hash ==
+             <<182, 157, 193, 195, 194, 54, 161, 104, 62, 219, 55, 39, 12, 127, 11, 187, 120, 98,
+               218, 185, 11, 61, 167, 121, 228, 8, 215, 53, 110, 89, 4, 128>>
+  end
+
+  test ".load does not modify the hash, since the hash cannot be reversed" do
+    hash =
+      <<16, 231, 67, 229, 9, 181, 13, 87, 69, 76, 227, 205, 43, 124, 16, 75, 46, 161, 206, 219,
+        141, 203, 199, 88, 112, 1, 204, 189, 109, 248, 22, 254>>
+
+    assert {:ok, ^hash} = Hash.load(hash)
+  end
+end

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -13,4 +13,12 @@ defmodule Fields.HelpersTest do
     hash = Helpers.hash(:argon2, password)
     assert Argon2.verify_pass(to_string(password), hash)
   end
+
+  test "hash/2 uses sha256 to hash a value" do
+    hash = Helpers.hash(:sha256, "alex@example.com")
+
+    assert hash ==
+             <<225, 207, 237, 158, 254, 87, 155, 207, 32, 13, 44, 208, 213, 24, 120, 1, 18, 140,
+               174, 94, 142, 95, 200, 228, 84, 25, 21, 163, 194, 121, 117, 244>>
+  end
 end

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -1,0 +1,16 @@
+defmodule Fields.HelpersTest do
+  use ExUnit.Case
+  alias Fields.Helpers
+
+  test "hash/2 uses Argon2id to Hash a value" do
+    password = "password"
+    hash = Helpers.hash(:argon2, password)
+    assert Argon2.verify_pass(password, hash)
+  end
+
+  test "hash/2 works with numbers" do
+    password = 123
+    hash = Helpers.hash(:argon2, password)
+    assert Argon2.verify_pass(to_string(password), hash)
+  end
+end

--- a/test/password_test.exs
+++ b/test/password_test.exs
@@ -14,7 +14,7 @@ defmodule Fields.PasswordTest do
   test ".dump returns an Argon2id Hash given a password string" do
     {:ok, result} = Password.dump("password")
     assert is_binary(result)
-    assert String.starts_with?(result, "$argon2id$v=19$m=65536,t=6,p=1$")
+    assert String.starts_with?(result, "$argon2")
   end
 
   test ".dump uses Argon2id to Hash a value" do

--- a/test/password_test.exs
+++ b/test/password_test.exs
@@ -1,0 +1,30 @@
+defmodule Fields.PasswordTest do
+  use ExUnit.Case
+  alias Fields.{Password, Helpers}
+
+  test ".type is :binary" do
+    assert Password.type() == :binary
+  end
+
+  test ".cast converts a value to a string" do
+    assert {:ok, "42"} == Password.cast(42)
+    assert {:ok, "atom"} == Password.cast(:atom)
+  end
+
+  test ".dump returns an Argon2id Hash given a password string" do
+    {:ok, result} = Password.dump("password")
+    assert is_binary(result)
+    assert String.starts_with?(result, "$argon2id$v=19$m=65536,t=6,p=1$")
+  end
+
+  test ".dump uses Argon2id to Hash a value" do
+    password = "EverythingisAwesome"
+    {:ok, hash} = Password.dump(password)
+    assert Argon2.verify_pass(password, hash)
+  end
+
+  test ".load does not modify the hash, since the hash cannot be reversed" do
+    hash = Helpers.hash(:argon2, "password")
+    assert {:ok, ^hash} = Password.load(hash)
+  end
+end

--- a/test/validate_test.exs
+++ b/test/validate_test.exs
@@ -4,15 +4,17 @@ defmodule Fields.ValidateTest do
   use ExUnitProperties
 
   def valid_local() do
-    valid_chars =
-      '!#$%&\'*+-/=?^_`{|}~'
-      |> Enum.concat(?a..?z)
-      |> Enum.concat(?A..?Z)
-
-    StreamData.string(valid_chars, min_length: 1)
+    '!#$%&\'*+-/=?^_`{|}~'
+    |> Enum.concat(?a..?z)
+    |> Enum.concat(?A..?Z)
+    |> StreamData.string(min_length: 1)
   end
 
-  property "local part of email" do
+  def valid_domain() do
+    StreamData.string(:alphanumeric, min_length: 1, max_length: 63)
+  end
+
+  property "valid local part of email" do
     # local part of email can contain alphanumeric characters
     check all local <- string(:alphanumeric, min_length: 1) do
       email = local <> "@testing.com"
@@ -49,11 +51,95 @@ defmodule Fields.ValidateTest do
       email = local <> "." <> "@testing.com"
       refute Validate.email(email)
     end
+
+    # local part of email can not contain consecutive .
+    check all left <- valid_local(),
+              right <- valid_local() do
+      email = left <> ".." <> right <> "@testing.com"
+      refute Validate.email(email)
+    end
   end
 
-  property "must contain @" do
+  property "must contain one @" do
     check all email <- string(:ascii) |> filter(&(!String.contains?(&1, "@"))) do
       refute Validate.email(email)
+    end
+
+    check all left <- valid_local(),
+              right <- valid_local() do
+      email = left <> "@" <> right <> "@testing.com"
+      refute Validate.email(email)
+    end
+  end
+
+  property "valid domain" do
+    # domain can contain alphanumeric characters
+    check all domain <- valid_domain() do
+      email = "test@" <> domain
+      assert Validate.email(email)
+    end
+
+    # domain cannot be longer than 63 characters
+    check all domain <- string(:alphanumeric, min_length: 64) do
+      email = "test@" <> domain
+      refute Validate.email(email)
+    end
+
+    # two domains can be separated by a .
+    check all first <- valid_domain(),
+              second <- valid_domain() do
+      email = "test@" <> first <> "." <> second
+      assert Validate.email(email)
+    end
+
+    # one domain can have a hyphen
+    check all first <- string(:alphanumeric, min_length: 1, max_length: 31),
+              second <- string(:alphanumeric, min_length: 1, max_length: 31) do
+      email = "test@" <> first <> "-" <> second
+      assert Validate.email(email)
+    end
+
+    # hyphen cannot be at start of domain
+    check all domain <- valid_domain() do
+      email = "test@" <> "-" <> domain
+      refute Validate.email(email)
+    end
+
+    # hyphen cannot be at end of domain
+    check all domain <- valid_domain() do
+      email = "test@" <> domain <> "-"
+      refute Validate.email(email)
+    end
+
+    # hyphen cannot be at end of first domain
+    check all first <- valid_domain(),
+              second <- valid_domain() do
+      email = "test@" <> first <> "-." <> second
+      refute Validate.email(email)
+    end
+
+    # hyphen cannot be at end of second domain
+    check all first <- valid_domain(),
+              second <- valid_domain() do
+      email = "test@" <> first <> "." <> second <> "-"
+      refute Validate.email(email)
+    end
+  end
+
+  property "valid email" do
+    # single domain
+    check all local <- valid_local(),
+              domain <- valid_domain() do
+      email = local <> "@" <> domain
+      assert Validate.email(email)
+    end
+
+    # two domains
+    check all local <- valid_local(),
+              first_domain <- valid_domain(),
+              second_domain <- valid_domain() do
+      email = local <> "@" <> first_domain <> "." <> second_domain
+      assert Validate.email(email)
     end
   end
 end

--- a/test/validate_test.exs
+++ b/test/validate_test.exs
@@ -1,0 +1,59 @@
+defmodule Fields.ValidateTest do
+  use ExUnit.Case
+  alias Fields.Validate
+  use ExUnitProperties
+
+  def valid_local() do
+    valid_chars =
+      '!#$%&\'*+-/=?^_`{|}~'
+      |> Enum.concat(?a..?z)
+      |> Enum.concat(?A..?Z)
+
+    StreamData.string(valid_chars, min_length: 1)
+  end
+
+  property "local part of email" do
+    # local part of email can contain alphanumeric characters
+    check all local <- string(:alphanumeric, min_length: 1) do
+      email = local <> "@testing.com"
+      assert Validate.email(email)
+    end
+
+    # local part of email can contain these special characters
+    check all local <- string('!#$%&\'*+-/=?^_`{|}~', min_length: 1) do
+      email = local <> "@testing.com"
+      assert Validate.email(email)
+    end
+
+    # local part of email can contain a combination of alphanumeric and special characters
+    check all local <- valid_local() do
+      email = local <> "@testing.com"
+      assert Validate.email(email)
+    end
+
+    # local part of email can contain .
+    check all left <- valid_local(),
+              right <- valid_local() do
+      email = left <> "." <> right <> "@testing.com"
+      assert Validate.email(email)
+    end
+
+    # local part of email can not start with .
+    check all local <- valid_local() do
+      email = "." <> local <> "@testing.com"
+      refute Validate.email(email)
+    end
+
+    # local part of email can not end with .
+    check all local <- valid_local() do
+      email = local <> "." <> "@testing.com"
+      refute Validate.email(email)
+    end
+  end
+
+  property "must contain @" do
+    check all email <- string(:ascii) |> filter(&(!String.contains?(&1, "@"))) do
+      refute Validate.email(email)
+    end
+  end
+end


### PR DESCRIPTION
Adds hashed, password and encrypted fields. (Mostly taken from https://github.com/dwyl/phoenix-ecto-encryption-example courtesy of @nelsonic )

~~Still working on: being able to extend these fields as macros. For example, making an `email` field that extends the `encrypted` field, taking the callbacks we already have, but with the ability to add other functions/attributes.~~

* Adds EmailPlaintext, EmailHash and EmailEncrypted fields
* Uses existing Encrypted and Hash functions in EmailEncrypted and EmailHash fields.
* Adds validation for emails using regex, tested with property based testing
