### PR TITLE
corrects error returned from invalid data

### DIFF
--- a/lib/address.ex
+++ b/lib/address.ex
@@ -19,7 +19,7 @@ defmodule Fields.Address do
   def cast(value) do
     case Validate.address(value) do
       true -> {:ok, to_string(value)}
-      false -> {:error, address: :invalid}
+      false -> :error
     end
   end
 

--- a/lib/email_plaintext.ex
+++ b/lib/email_plaintext.ex
@@ -19,7 +19,7 @@ defmodule Fields.EmailPlaintext do
   def cast(value) do
     case Validate.email(value) do
       true -> {:ok, to_string(value)}
-      false -> {:error, email: :invalid}
+      false -> :error
     end
   end
 

--- a/lib/phone_number.ex
+++ b/lib/phone_number.ex
@@ -19,7 +19,7 @@ defmodule Fields.PhoneNumber do
   def cast(value) do
     case Validate.phone_number(value) do
       true -> {:ok, to_string(value)}
-      false -> {:error, phone_number: :invalid}
+      false -> :error
     end
   end
 

--- a/lib/postcode.ex
+++ b/lib/postcode.ex
@@ -18,7 +18,7 @@ defmodule Fields.Postcode do
   def cast(value) do
     case Validate.postcode(value) do
       true -> {:ok, to_string(value)}
-      false -> {:error, postcode: :invalid}
+      false -> :error
     end
   end
 

--- a/lib/postcode_encrypted.ex
+++ b/lib/postcode_encrypted.ex
@@ -10,7 +10,7 @@ defmodule Fields.PostcodeEncrypted do
         field(:postcode, Fields.PostcodeEncrypted)
       end
   """
-  alias Fields.{Postcode, Encrypted, Validate}
+  alias Fields.{Postcode, Encrypted}
 
   @behaviour Ecto.Type
 

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -19,8 +19,8 @@ defmodule Fields.AddressTest do
     end
 
     test "Address.cast validates Address" do
-      assert {:error, [address: :invalid]} == Address.cast("")
-      assert {:error, [address: :invalid]} == AddressEncrypted.cast("")
+      assert :error == Address.cast("")
+      assert :error == AddressEncrypted.cast("")
     end
   end
 

--- a/test/email_test.exs
+++ b/test/email_test.exs
@@ -24,9 +24,9 @@ defmodule Fields.EmailTest do
     end
 
     test "Email.cast validates email" do
-      assert {:error, [email: :invalid]} == EmailPlaintext.cast("invalid_email")
-      assert {:error, [email: :invalid]} == EmailEncrypted.cast("invalid_email")
-      assert {:error, [email: :invalid]} == EmailHash.cast("invalid_email")
+      assert :error == EmailPlaintext.cast("invalid_email")
+      assert :error == EmailEncrypted.cast("invalid_email")
+      assert :error == EmailHash.cast("invalid_email")
     end
   end
 

--- a/test/phone_test.exs
+++ b/test/phone_test.exs
@@ -21,10 +21,10 @@ defmodule Fields.PhoneNumberTest do
     end
 
     test "PhoneNumber.cast validates PhoneNumber" do
-      assert {:error, [phone_number: :invalid]} == PhoneNumber.cast("012345")
-      assert {:error, [phone_number: :invalid]} == PhoneNumber.cast("bad_number")
-      assert {:error, [phone_number: :invalid]} == PhoneNumberEncrypted.cast("012345")
-      assert {:error, [phone_number: :invalid]} == PhoneNumberEncrypted.cast("bad_number")
+      assert :error == PhoneNumber.cast("012345")
+      assert :error == PhoneNumberEncrypted.cast("012345")
+      assert :error == PhoneNumber.cast("bad_number")
+      assert :error == PhoneNumberEncrypted.cast("bad_number")
     end
   end
 

--- a/test/postcode_test.exs
+++ b/test/postcode_test.exs
@@ -19,8 +19,8 @@ defmodule Fields.PostcodeTest do
     end
 
     test "Postcode.cast validates postcode" do
-      assert {:error, [postcode: :invalid]} == Postcode.cast("invalid_postcode")
-      assert {:error, [postcode: :invalid]} == PostcodeEncrypted.cast("E2 777")
+      assert :error == Postcode.cast("invalid_postcode")
+      assert :error == PostcodeEncrypted.cast("E2 777")
     end
   end
 


### PR DESCRIPTION
When we return an error from a `cast` callback, ecto will automatically provide the name of the field and a invalid message, so all we need to actually return is an `:error` atom