### PR TITLE
adds test for local section of email containing only numbers #39

### DIFF
--- a/test/validate_test/email_test.exs
+++ b/test/validate_test/email_test.exs
@@ -15,6 +15,11 @@ defmodule Fields.ValidateEmailTest do
     StreamData.string(:alphanumeric, min_length: 1, max_length: 63)
   end
 
+  test "local part of email containing only numbers is valid"  do
+    email = "0123456@emample.com"
+    assert Validate.email(email)
+  end
+
   property "valid local part of email" do
     # local part of email can contain alphanumeric characters
     check all local <- string(:alphanumeric, min_length: 1) do

--- a/test/validate_test/email_test.exs
+++ b/test/validate_test/email_test.exs
@@ -15,7 +15,7 @@ defmodule Fields.ValidateEmailTest do
     StreamData.string(:alphanumeric, min_length: 1, max_length: 63)
   end
 
-  test "local part of email containing only numbers is valid"  do
+  test "local part of email containing only numbers is valid issue #39"  do
     email = "0123456@emample.com"
     assert Validate.email(email)
   end


### PR DESCRIPTION
Adds a test to confirm that numeric only emails are allowed in validate email #39 