### PR TITLE
Proposal: more flexible URL regex

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.11.0-otp-22
+erlang 23.1.1
+elixir 1.11.1-otp-23

--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -60,14 +60,10 @@ defmodule Fields.Validate do
 
   @doc """
   Validate the format of a url using a regex.
-  See https://git.io/fpdad for details on how the regex for validation was chosen
+  See https://stackoverflow.com/questions/42522442/how-to-validate-a-url-via-a-check-constraint-in-postgres/51965621 for details on how the regex for validation was chosen
   """
   def url(url) do
-    {:ok, regex} =
-      Regex.compile(
-        "^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\\.\d{1,3}){3})(?!127(?:\\.\d{1,3}){3})(?!169\\.254(?:\\.\d{1,3}){2})(?!192\\.168(?:\\.\d{1,3}){2})(?!172\\.(?:1[6-9]|2\d|3[0-1])(?:\\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:/[^\s]*)?$"
-      )
-
+    regex = ~r/(?:https?|ftp):\/\/(www\\.)?[-a-zA-Z0-9@:%._\+~#=]{2,255}\.[a-z]{2,9}\b([-a-zA-Z0-9@:%_+.,~#?!&>\/\/=]*)$/
     Regex.match?(regex, url)
   end
 

--- a/test/url_test.exs
+++ b/test/url_test.exs
@@ -13,6 +13,18 @@ defmodule Fields.UrlTest do
       assert {:ok, "http://www.test.com"} == Url.cast("http://www.test.com")
     end
 
+    test "Url.cast accepts a string with uppercase characters" do
+      assert {:ok, "http://www.Test.com"} == Url.cast("http://www.Test.com")
+    end
+
+    test "Url.cast accepts a url with a query string" do
+      assert {:ok, "http://www.test.com?foo=bar"} == Url.cast("http://www.test.com?foo=bar")
+    end
+
+    test "Url.cast accepts a url with a fragment" do
+      assert {:ok, "http://www.test.com#something"} == Url.cast("http://www.test.com#something")
+    end
+
     test "Url.cast requires a protocol scheme" do
       assert {:ok, "https://www.test.com"} == Url.cast("https://www.test.com")
       assert {:ok, "http://www.test.com"} == Url.cast("http://www.test.com")


### PR DESCRIPTION
The url regex that is in place fails on the additional tests in this PR. I think we should adopt a more flexible regex, along the lines of:

https://stackoverflow.com/questions/42522442/how-to-validate-a-url-via-a-check-constraint-in-postgres/51965621

Thoughts?