### PR TITLE
Update application configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,9 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 
-config :fields,
-  encryption_keys: System.get_env("ENCRYPTION_KEYS"),
-  secret_key_base: System.get_env("SECRET_KEY_BASE")
-
-#
 if Mix.env() == :test, do: import_config("#{Mix.env()}.exs")

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Fields.MixProject do
     [
       app: :fields,
       description: "A collection of useful fields for building Phoenix apps faster!",
-      version: "2.8.1",
+      version: "2.8.2",
       elixir: ">= 1.10.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -25,7 +25,11 @@ defmodule Fields.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      env: [
+        encryption_keys: System.get_env("ENCRYPTION_KEYS"),
+        secret_key_base: System.get_env("SECRET_KEY_BASE")
+      ]
     ]
   end
 


### PR DESCRIPTION
ref #86
Define the application coniguration in `mix.exs` file.
This PR should resolve the current issue, however it might be good to review later if we can avoid application configuration in the package completely as mentioned in Elixir library guideline: https://hexdocs.pm/elixir/master/library-guidelines.html#avoid-application-configuration