### PR TITLE
fix: accept nil values when validating URLs

### DIFF
--- a/lib/url.ex
+++ b/lib/url.ex
@@ -14,6 +14,8 @@ defmodule Fields.Url do
 
   def type, do: :string
 
+  def cast(nil), do: {:ok, nil}
+
   def cast(value) do
     value = value |> to_string() |> String.trim()
 

--- a/test/url_test.exs
+++ b/test/url_test.exs
@@ -9,6 +9,10 @@ defmodule Fields.UrlTest do
   end
 
   describe "cast" do
+    test "Url.cast accepts a nil" do
+      assert {:ok, nil} == Url.cast(nil)
+    end
+
     test "Url.cast accepts a string" do
       assert {:ok, "http://www.test.com"} == Url.cast("http://www.test.com")
     end


### PR DESCRIPTION
without this, it's impossible to allow nil values.

nil constraints should be set elsewhere and be allowed in this library from my pov.
