### PR TITLE
Prototype of base64 wrapped encrypted value.

### DIFF
--- a/lib/encrypted-base64.ex
+++ b/lib/encrypted-base64.ex
@@ -1,0 +1,50 @@
+defmodule Fields.EncryptedBase64 do
+  @moduledoc """
+  An Ecto Type for encrypted fields.
+  See `Fields.AES` for details on encryption/decryption.
+
+  ## Example
+
+        schema "users" do
+          field :name, Fields.EncryptedBase64
+        end
+  """
+  use Ecto.Type
+  alias Fields.AES
+  require Logger
+
+  def type(),
+    do: :string
+
+  def cast(value),
+    do: {:ok, to_string(value)}
+
+  def dump(value),
+    do:
+      value
+      |> then(fn
+        # Input value is nil. Store as-is. It's the developer's job
+        # to run validations if they don't want that.
+        nil -> value
+        # Value is any kind of binary. Encrypt, and base64 encode.
+        <<>> <> _ -> value |> to_string |> AES.encrypt() |> Base.encode64(padding: true)
+      end)
+      |> then(& {:ok, &1})
+
+  def load(value),
+    do:
+      value
+      |> then(fn
+        # We got nil from the database... Just use that.
+        nil -> value
+        # We got any binary. Decode64 and decrypt.
+        <<>> <> _ -> value |> Base.decode64!(padding: true) |> AES.decrypt()
+      end)
+      |> then(& {:ok, &1})
+
+  def embed_as(_),
+    do: :dump
+
+  def equal?(term1, term2),
+    do: term1 == term2
+end


### PR DESCRIPTION
Ok so - unable to use this for embeds or anything that stores into `JSON` or `JSONB` at database / field level.
That's because non-standard strings aren't possible to express without heavy escaping in JSON.
So why not wrap them into a B64 step?

Super-useful if you want to be able to use it in an `embedded_schema`...

Ah yeah also as a side note - if you have `  def embed_as(_), do: :self` then Ecto will skip the `dump` and `load` calls **silently**. Not great, as it means that users who use `Fields.Encrypted*` types won't know that they in fact aren't encrypting anything... I checked myself.
So to force Ecto to `load` / `dump`, I used `def embebd_as(_), do: :dump` and it seems to work for embeds as well now.